### PR TITLE
TECH-663 - Not triggering Github Actions deployment when the chainlog…

### DIFF
--- a/logger.py
+++ b/logger.py
@@ -82,7 +82,7 @@ def update(chain):
         contents = json.dumps(log, indent=2)
         log_file.write(contents)
         log_file.close()
-        message = "feat: add chainlog file for {} v{}".format(chain, version)
+        message = "[skip ci] feat: add chainlog file for {} v{}".format(chain, version)
         push(path, contents, message)
         active_path = "api/{}/active.json".format(chain)
         active_file = open(active_path, "w")


### PR DESCRIPTION
…-logger script commits the changed files back to the repo

According to https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs this should work