### PR TITLE
TECH-3399 - Increase resources for chainlog-logger

### DIFF
--- a/deploy/staging/chainlog-logger.yaml
+++ b/deploy/staging/chainlog-logger.yaml
@@ -15,10 +15,10 @@ podAnnotations:
   reloader.stakater.com/auto: "true"
 resources:
   limits:
-    cpu: 200m
+    cpu: 500m
     memory: 256Mi
   requests:
-    cpu: 100m
+    cpu: 350m
     memory: 128Mi
 autoscaling:
   enabled: false


### PR DESCRIPTION
`chainlog-logger` is continuously using about `340m` of CPU, with an average of ~`300m`.