### PR TITLE
TECH-3399 - Increase resources for chainlog-logger (staging)

### DIFF
--- a/deploy/staging/chainlog-logger.yaml
+++ b/deploy/staging/chainlog-logger.yaml
@@ -15,10 +15,10 @@ podAnnotations:
   reloader.stakater.com/auto: "true"
 resources:
   limits:
-    cpu: 200m
+    cpu: 500m
     memory: 256Mi
   requests:
-    cpu: 100m
+    cpu: 350m
     memory: 128Mi
 autoscaling:
   enabled: false


### PR DESCRIPTION
`chainlog-logger` is continuously using about `340m` of CPU, with an average of ~`300m`.

I know that it says `replicaCount: 0`, but for some reason it's running. If it has to be removed from the cluster, please let me know so I can close this PR and work on that instead.