### PR TITLE
Tech 4655 incr timeouts

### DIFF
--- a/deploy/prod/chainlog-logger.yaml
+++ b/deploy/prod/chainlog-logger.yaml
@@ -46,6 +46,7 @@ livenessProbe:
       - ps -ef | grep logger.py | grep -v grep
   initialDelaySeconds: 5
   periodSeconds: 30
+  timeoutSeconds: 5
 readinessProbe:
   exec:
     command:
@@ -54,3 +55,4 @@ readinessProbe:
       - ps -ef | grep logger.py | grep -v grep
   initialDelaySeconds: 5
   periodSeconds: 30
+  timeoutSeconds: 5

--- a/deploy/staging/chainlog-logger.yaml
+++ b/deploy/staging/chainlog-logger.yaml
@@ -47,6 +47,7 @@ livenessProbe:
       - ps -ef | grep logger.py | grep -v grep
   initialDelaySeconds: 5
   periodSeconds: 30
+  timeoutSeconds: 5
 readinessProbe:
   exec:
     command:
@@ -55,3 +56,4 @@ readinessProbe:
       - ps -ef | grep logger.py | grep -v grep
   initialDelaySeconds: 5
   periodSeconds: 30
+  timeoutSeconds: 5


### PR DESCRIPTION
Increased probe timeouts to 5s, as 1s is not long enough.